### PR TITLE
Add intro, explainers, helpers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,12 +17,18 @@ export default function App() {
   }, [progress]);
 
   return (
-    <div className="container mx-auto p-4 space-y-8">
-      <h1 className="text-3xl font-bold text-center text-indigo-600">CDPAgentX Mini-Course</h1>
+    <main className="container mx-auto p-4 space-y-8">
+      {/* 🛈 course-intro */}
+      <section className="mx-auto max-w-4xl text-center">
+        <h1 className="text-3xl font-bold text-indigo-400 mb-2">CDPAgentX Mini-Course</h1>
+        <p className="text-slate-300 text-sm md:text-base">
+          Tweak the knobs a CDP marketer uses every day and watch the key metrics react in real&nbsp;time.
+        </p>
+      </section>
       <SegmentationBasics onComplete={() => setProgress(p => ({ ...p, seg: true }))} />
       <ChannelOrchestration onComplete={() => setProgress(p => ({ ...p, orch: true }))} />
       <GuardrailsCaps onComplete={() => setProgress(p => ({ ...p, guard: true }))} />
       <AgenticOptimiser onComplete={() => setProgress(p => ({ ...p, optimise: true }))} />
-    </div>
+    </main>
   );
 }

--- a/src/modules/AgenticOptimiser.jsx
+++ b/src/modules/AgenticOptimiser.jsx
@@ -31,16 +31,35 @@ export default function AgenticOptimiser({ onComplete }) {
   return (
     <section className="space-y-4">
       <h2 className="text-xl font-semibold text-amber-400">Agentic Optimiser</h2>
+      <p className="text-slate-400 text-sm">
+        Give the optimiser a revenue goal, tolerance band, and decide how much to
+        explore new tactics versus exploit proven winners.
+      </p>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <label className="flex flex-col space-y-1">
-          <span className="text-sm">Revenue target</span>
+          <span className="text-sm">
+            Revenue target <span className="text-xs text-slate-500">(USD)</span>
+          </span>
           <input type="number" className="p-1 text-black" value={target} onChange={e => setTarget(Number(e.target.value))} />
         </label>
         <label className="flex flex-col space-y-1">
-          <span className="text-sm">Tolerance %</span>
+          <span className="text-sm">
+            Tolerance % <span className="text-xs text-slate-500">(acceptable drift)</span>
+          </span>
           <input type="number" className="p-1 text-black" value={tolerance} onChange={e => setTolerance(Number(e.target.value))} />
         </label>
-        <Slider label="Explore vs Exploit" value={explore} onChange={setExplore} min={0} max={100} />
+        <Slider
+          label={
+            <span>
+              Explore vs Exploit{' '}
+              <span className="text-xs text-slate-500">(0 = exploit only)</span>
+            </span>
+          }
+          value={explore}
+          onChange={setExplore}
+          min={0}
+          max={100}
+        />
       </div>
       <svg width={width} height={height} className="bg-slate-800 rounded">
         <polyline points={path} fill="none" stroke="#10b981" strokeWidth="2" />

--- a/src/modules/ChannelOrchestration.jsx
+++ b/src/modules/ChannelOrchestration.jsx
@@ -24,6 +24,9 @@ export default function ChannelOrchestration({ onComplete }) {
   return (
     <section className="space-y-4">
       <h2 className="text-xl font-semibold text-amber-400">Channel Orchestration</h2>
+      <p className="text-slate-400 text-sm">
+        Drag channels to test how mix and order boost open/click lift.
+      </p>
       <ul className="space-y-2">
         {steps.map((step, i) => (
           <li key={step} className="flex justify-between items-center bg-slate-800 p-2 rounded">
@@ -35,6 +38,7 @@ export default function ChannelOrchestration({ onComplete }) {
           </li>
         ))}
       </ul>
+      <span className="text-xs text-slate-500 ml-2">(first touch carries most weight)</span>
       <MetricCard label="Open/Click lift" value={lift} threshold={0.05} />
     </section>
   );

--- a/src/modules/GuardrailsCaps.jsx
+++ b/src/modules/GuardrailsCaps.jsx
@@ -17,12 +17,21 @@ export default function GuardrailsCaps({ onComplete }) {
   return (
     <section className="space-y-4">
       <h2 className="text-xl font-semibold text-amber-400">Guardrails & Caps</h2>
+      <p className="text-slate-400 text-sm">
+        Keep campaigns compliant by setting message caps and forbidden words.
+      </p>
       <label className="block">
-        <span className="text-sm">Daily message cap</span>
+        <span className="text-sm">
+          Daily message cap{' '}
+          <span className="text-xs text-slate-500">(max per user/day)</span>
+        </span>
         <input type="number" className="w-full text-black p-1" value={cap} onChange={e => setCap(Number(e.target.value))} />
       </label>
       <label className="block">
-        <span className="text-sm">Forbidden words</span>
+        <span className="text-sm">
+          Forbidden words{' '}
+          <span className="text-xs text-slate-500">(comma-separated)</span>
+        </span>
         <textarea className="w-full text-black p-1" rows="3" value={banned} onChange={e => setBanned(e.target.value)} />
       </label>
       <div className="bg-slate-800 h-4 rounded-full" aria-label="Compliance bar">

--- a/src/modules/SegmentationBasics.jsx
+++ b/src/modules/SegmentationBasics.jsx
@@ -24,12 +24,59 @@ export default function SegmentationBasics({ onComplete }) {
   return (
     <section className="space-y-4">
       <h2 className="text-xl font-semibold text-amber-400">Segmentation Basics</h2>
+      {/* 🛈 section-explainer */}
+      <p className="text-slate-400 text-sm">
+        Adjust RFM thresholds to see how strict rules narrow or widen your audience.
+        Toggle “Similarity search” to bring in look-alike customers.
+      </p>
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Slider label="Recency days" value={recency} onChange={setRecency} min={0} max={60} />
-        <Slider label="Frequency" value={frequency} onChange={setFrequency} min={1} max={10} />
-        <Slider label="Monetary $" value={monetary} onChange={setMonetary} min={0} max={500} />
+        <Slider
+          label={
+            <span>
+              Recency days{' '}
+              <span className="text-xs text-slate-500">(lower includes dormant users)</span>
+            </span>
+          }
+          value={recency}
+          onChange={setRecency}
+          min={0}
+          max={60}
+        />
+        <Slider
+          label={
+            <span>
+              Frequency{' '}
+              <span className="text-xs text-slate-500">(higher = power shoppers)</span>
+            </span>
+          }
+          value={frequency}
+          onChange={setFrequency}
+          min={1}
+          max={10}
+        />
+        <Slider
+          label={
+            <span>
+              Monetary ${' '}
+              <span className="text-xs text-slate-500">(minimum lifetime spend)</span>
+            </span>
+          }
+          value={monetary}
+          onChange={setMonetary}
+          min={0}
+          max={500}
+        />
       </div>
-      <Toggle label="Similarity search" checked={similarity} onChange={setSimilarity} />
+      <Toggle
+        label={
+          <span>
+            Similarity search{' '}
+            <span className="text-xs text-slate-500">(vector look-alikes)</span>
+          </span>
+        }
+        checked={similarity}
+        onChange={setSimilarity}
+      />
       <MetricCard label="Reachable audience" value={reach} threshold={0.7} />
     </section>
   );


### PR DESCRIPTION
## Summary
- insert course intro in App
- add section explainer and helper text to Segmentation Basics controls
- add helper copy in Channel Orchestration
- explain guardrail options and label hints
- add optimiser explainer and helper spans

## Testing
- `npm test` *(fails: Missing script)*